### PR TITLE
Eliminate reflection from superstring.core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pom.xml.asc
 /.nrepl-port
 /doc
 /update-docs.sh
+/.project
+/bin/
+/.classpath

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 /.project
 /bin/
 /.classpath
+/.settings/


### PR DESCRIPTION
This PR adds type hints and makes other minor changes to superstring.core in order to eliminate reflection. This provides a significant improvement in performance.